### PR TITLE
adding \Hoa\Core\Event\Listener::detachAll method in order to provide an...

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -486,6 +486,22 @@ class Listener {
     }
 
     /**
+     * Detach every callable attached to given listenerId from a listenable component.
+     *
+     * @access public
+     * @param  string  in   $listenerId   Listener ID.
+     * @param  array   out  $released     The number of callback detached
+     * @return \Hoa\Core\Event\Listener
+     */
+    public function detachAll ( $listenerId, & $released = null ) {
+
+        $released = isset($this->_callable[$listenerId]) ? $this->_callable[$listenerId] : array();
+        unset($this->_callable[$listenerId]);
+
+        return $this;
+    }
+
+    /**
      * Check if a listener exists.
      *
      * @access  public


### PR DESCRIPTION
... easy and comprehensive way to unbind events

The client sometimes (in fact most of the time) need to detach an event handler without knowing its callback.
