### PR TITLE
Import with * and composer must have key 0 and 1 strtolowed.

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -294,6 +294,12 @@ class Consistency implements \ArrayAccess {
 
         if(false !== strpos($all, '*')) {
 
+            if(WITH_COMPOSER) {
+
+                $explode[0] = strtolower($explode[0]);
+                $explode[1] = strtolower($explode[1]);
+            }
+
             $backup     = $explode[0];
             $explode[0] = $root . $explode[0];
             $countFrom  = strlen($explode[0]) + 1;


### PR DESCRIPTION
At this moment, it tries to autoload with

```
<pre>array(5) {
  [0]=>
  string(3) "Hoa"
  [1]=>
  string(5) "Ruler"
  [2]=>
  string(5) "Model"
  [3]=>
  string(10) "Comparator"
  [4]=>
  string(1) "*"
}
```

which must be

```
<pre>array(5) {
  [0]=>
  string(3) "hoa"
  [1]=>
  string(5) "ruler"
  [2]=>
  string(5) "Model"
  [3]=>
  string(10) "Comparator"
  [4]=>
  string(1) "*"
}
```
