### PR TITLE
Roots on Windows

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -431,10 +431,7 @@ class Consistency {
         if(null === $from)
             $from = $this->_from[0];
 
-        $this->_roots[$from] = preg_split('#(?<!\\\);#', $root);
-
-        foreach($this->_roots[$from] as &$freshroot)
-            $freshroot = str_replace('\;', ';', $freshroot);
+        $this->_roots[$from] = explode(';', $root);
 
         return $this;
     }


### PR DESCRIPTION
Bug appeared since [`Update compatibility with Windows.`](https://github.com/hoaproject/Core/commit/e06376f121b00d54223c259ce14157e02928d005) already on the [`Central`](https://github.com/hoaproject/Central/commit/eed03b85a0cee7777d0c65ef79ab1b4ba091b6d7)

When computing the Consistency::$_roots there are strange action on line 434 and 437.
I don't understand why restrict the split whit `(?<!\\\)` ?

On a Windows the $root parameter is like that `D:\testHoa\Embryo\Data\Library\;D:\lib\` (app_library_path;hoa_path)

Currently `Consistency::autoload()` can't do anything.
