### PR TITLE
Update timezone and locale

### DIFF
--- a/Core.php
+++ b/Core.php
@@ -174,10 +174,12 @@ class Core implements Parameter\Parameterizable {
                         array('hoa')
                     )));
 
+        setlocale(LC_CTYPE, 'C');
+
         $date = ini_get('date.timezone');
 
         if(empty($date))
-            ini_set('date.timezone', 'Europe/Paris');
+            ini_set('date.timezone', 'UTC');
 
         mb_internal_encoding('UTF-8');
 


### PR DESCRIPTION
Protect the code from turkish characters (and other UTF-8 chars).
For more information, see http://blog.mover.io/php-locale-and-basename/
