### PR TITLE
Same as #24

### DIFF
--- a/Core.php
+++ b/Core.php
@@ -174,10 +174,12 @@ class Core implements Parameter\Parameterizable {
                         array('hoa')
                     )));
 
+        setlocale(LC_CTYPE, 'C');
+
         $date = ini_get('date.timezone');
 
         if(empty($date))
-            ini_set('date.timezone', 'Europe/Paris');
+            ini_set('date.timezone', 'UTC');
 
         mb_internal_encoding('UTF-8');
 


### PR DESCRIPTION
_Why UTC?_
UTC is the new standard timezone (GMT is depricated), sorry for
Europe/Paris ;)
Moreover, MySQL doesn't care about timezones when inserting/updating
values. all it sees are time/date values and strings. (May be another
DB?)
E.G: If a japanese user runs the script for inserting a message in DB,
the developer have to translate it in an internal timezone. Then the
developer have to translate the internal timezone to a locale timezone
to a chilian user which runs the script.

_Why LC_CTYPE?_
Protect the code from turkish characters (and other UTF-8 chars).
It is important to place this call somewhere that ensures that it gets
called before any processing on strings is performed if you are
expecting to be dealing with unicode multibyte characters. This can
cause PHP to have some trouble parsing strings correctly when dealing
with multibyte characters.
E.G: An english people posts an internal message in turkish and the same
script sends an email notification in german. An error occured somewhere
like in the Memcached driver. (Whoo, a C++ error in PHP!)
