### PR TITLE
Constantize: change ';' into constant RS as RootSeparator

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -428,7 +428,7 @@ class Consistency
             $this->_roots[$from] = [];
         }
 
-        foreach (explode(';', $root) as $r) {
+        foreach (explode(RS, $root) as $r) {
             $this->_roots[$from][] = rtrim($r, '/\\') . DS;
         }
 

--- a/Core.php
+++ b/Core.php
@@ -128,30 +128,32 @@ class Core implements Parameter\Parameterizable
      */
     private function __construct()
     {
-        static::_define('SUCCEED',       true);
-        static::_define('FAILED',        false);
-        static::_define('…',             '__hoa_core_fill');
-        static::_define('DS',            DIRECTORY_SEPARATOR);
-        static::_define('PS',            PATH_SEPARATOR);
-        static::_define('CRLF',          "\r\n");
-        static::_define('OS_WIN',        defined('PHP_WINDOWS_VERSION_PLATFORM'));
-        static::_define('S_64_BITS',     PHP_INT_SIZE == 8);
-        static::_define('S_32_BITS',     !S_64_BITS);
-        static::_define('PHP_INT_MIN',   ~PHP_INT_MAX);
-        static::_define('PHP_FLOAT_MIN', (float) PHP_INT_MIN);
-        static::_define('PHP_FLOAT_MAX', (float) PHP_INT_MAX);
-        static::_define('π',             M_PI);
-        static::_define('void',          (unset) null);
-        static::_define('_public',       1);
-        static::_define('_protected',    2);
-        static::_define('_private',      4);
-        static::_define('_static',       8);
-        static::_define('_abstract',     16);
-        static::_define('_pure',         32);
-        static::_define('_final',        64);
-        static::_define('_dynamic',      ~_static);
-        static::_define('_concrete',     ~_abstract);
-        static::_define('_overridable',  ~_final);
+        static::_define('SUCCEED',          true);
+        static::_define('FAILED',           false);
+        static::_define('…',                '__hoa_core_fill');
+        static::_define('DS',               DIRECTORY_SEPARATOR);
+        static::_define('PS',               PATH_SEPARATOR);
+        static::_define('ROOT_SEPARATOR',   ';');
+        static::_define('RS',               ROOT_SEPARATOR);
+        static::_define('CRLF',             "\r\n");
+        static::_define('OS_WIN',           defined('PHP_WINDOWS_VERSION_PLATFORM'));
+        static::_define('S_64_BITS',        PHP_INT_SIZE == 8);
+        static::_define('S_32_BITS',        !S_64_BITS);
+        static::_define('PHP_INT_MIN',      ~PHP_INT_MAX);
+        static::_define('PHP_FLOAT_MIN',    (float) PHP_INT_MIN);
+        static::_define('PHP_FLOAT_MAX',    (float) PHP_INT_MAX);
+        static::_define('π',                M_PI);
+        static::_define('void',             (unset) null);
+        static::_define('_public',          1);
+        static::_define('_protected',       2);
+        static::_define('_private',         4);
+        static::_define('_static',          8);
+        static::_define('_abstract',        16);
+        static::_define('_pure',            32);
+        static::_define('_final',           64);
+        static::_define('_dynamic',         ~_static);
+        static::_define('_concrete',        ~_abstract);
+        static::_define('_overridable',     ~_final);
         static::_define('WITH_COMPOSER', class_exists('Composer\Autoload\ClassLoader', false) ||
                                          ('cli' === PHP_SAPI &&
                                          file_exists(__DIR__ . DS . '..' . DS . '..' . DS . 'autoload.php')));
@@ -229,7 +231,7 @@ class Core implements Parameter\Parameterizable
                 'protocol.Data/Etc'               => 'Etc' . DS,
                 'protocol.Data/Etc/Configuration' => 'Configuration' . DS,
                 'protocol.Data/Etc/Locale'        => 'Locale' . DS,
-                'protocol.Data/Library'           => 'Library' . DS . 'Hoathis' . DS . ';' .
+                'protocol.Data/Library'           => 'Library' . DS . 'Hoathis' . DS . RS .
                                                      'Library' . DS . 'Hoa' . DS,
                 'protocol.Data/Lost+found'        => 'Lost+found' . DS,
                 'protocol.Data/Temporary'         => 'Temporary' . DS,
@@ -240,12 +242,12 @@ class Core implements Parameter\Parameterizable
                 'protocol.Data/Variable/Private'  => 'Private' . DS,
                 'protocol.Data/Variable/Run'      => 'Run' . DS,
                 'protocol.Data/Variable/Test'     => 'Test' . DS,
-                'protocol.Library'                => '(:%protocol.Data:)Library' . DS . 'Hoathis' . DS . ';' .
-                                                     '(:%protocol.Data:)Library' . DS . 'Hoa' . DS . ';' .
-                                                     '(:%root.hoa:)' . DS . 'Hoathis' . DS . ';' .
+                'protocol.Library'                => '(:%protocol.Data:)Library' . DS . 'Hoathis' . DS . RS .
+                                                     '(:%protocol.Data:)Library' . DS . 'Hoa' . DS . RS .
+                                                     '(:%root.hoa:)' . DS . 'Hoathis' . DS . RS .
                                                      '(:%root.hoa:)' . DS . 'Hoa' . DS,
 
-                'namespace.prefix.*'           => '(:%protocol.Data:)Library' . DS . ';(:%root.hoa:)' . DS,
+                'namespace.prefix.*'           => '(:%protocol.Data:)Library' . DS . RS . '(:%root.hoa:)' . DS,
                 'namespace.prefix.Application' => '(:%root.application:h:)' . DS,
             ]
         );

--- a/Protocol.php
+++ b/Protocol.php
@@ -322,12 +322,12 @@ abstract class Protocol implements \ArrayAccess, \IteratorAggregate
     protected function _resolveChoice($reach, Array &$accumulator)
     {
         if (empty($accumulator)) {
-            $accumulator = explode(';', $reach);
+            $accumulator = explode(RS, $reach);
 
             return;
         }
 
-        if (false === strpos($reach, ';')) {
+        if (false === strpos($reach, RS)) {
             if (false !== $pos = strrpos($reach, "\r")) {
                 $reach = substr($reach, $pos + 1);
 
@@ -343,7 +343,7 @@ abstract class Protocol implements \ArrayAccess, \IteratorAggregate
             return;
         }
 
-        $choices     = explode(';', $reach);
+        $choices     = explode(RS, $reach);
         $ref         = $accumulator;
         $accumulator = [];
 
@@ -543,25 +543,25 @@ class Library extends Protocol
 
             $out = [];
 
-            foreach (explode(';', $this->_reach) as $part) {
+            foreach (explode(RS, $this->_reach) as $part) {
                 $out[] = "\r" . $part . strtolower($head) . $queue;
             }
 
             $out[] = "\r" . dirname(dirname(dirname(__DIR__))) . $queue;
 
-            return implode(';', $out);
+            return implode(RS, $out);
         }
 
         $out = [];
 
-        foreach (explode(';', $this->_reach) as $part) {
+        foreach (explode(RS, $this->_reach) as $part) {
             $pos   = strrpos(rtrim($part, DS), DS) + 1;
             $head  = substr($part, 0, $pos);
             $tail  = substr($part, $pos);
             $out[] = $head . strtolower($tail);
         }
 
-        $this->_reach = implode(';', $out);
+        $this->_reach = implode(RS, $out);
 
         return parent::reach($queue);
     }


### PR DESCRIPTION
RS is choose for RootSeparator and is as long as the DS (Directory) and PS (Path) constants. 
It should be more human readable for contributors ;) 


REM: Checktyle for the ending space of " * Read from stream"@Protocol.php:763