### PR TITLE
prevent auto-initializing if HOA_CREATOR is already defined

### DIFF
--- a/Core.php
+++ b/Core.php
@@ -174,10 +174,12 @@ class Core implements Parameter\Parameterizable {
                         array('hoa')
                     )));
 
+        setlocale(LC_CTYPE, 'C');
+
         $date = ini_get('date.timezone');
 
         if(empty($date))
-            ini_set('date.timezone', 'Europe/Paris');
+            ini_set('date.timezone', 'UTC');
 
         mb_internal_encoding('UTF-8');
 

--- a/Core.php
+++ b/Core.php
@@ -135,6 +135,7 @@ class Core implements Parameter\Parameterizable {
      */
     private function __construct ( ) {
 
+        static::_define('HOA_CREATOR',   __FILE__);
         static::_define('SUCCEED',       true);
         static::_define('FAILED',        false);
         static::_define('…',             '__hoa_core_fill');
@@ -519,6 +520,7 @@ function event ( $eventId ) {
 /**
  * Then, initialize Hoa.
  */
-\Hoa\Core::getInstance()->initialize();
+if (!defined('HOA_CREATOR'))
+    \Hoa\Core::getInstance()->initialize();
 
 }


### PR DESCRIPTION
Use case: 
`./Application/Public/index.php`
```php

define('__ROOT__', dirname(__DIR__));
define('HOA_CREATOR', __FILE__);
define('HOA_PATH', dirname(__ROOT__) . DIRECTORY_SEPARATOR . 'Hoa.central');
define('LIB_PATH', dirname(__ROOT__) . DIRECTORY_SEPARATOR . 'Libraries.hoa');

/*PRD~•/ error_reporting(NONE);  /•~PRD*/
/*DEV~*/ error_reporting(E_ALL); /*~DEV*/
set_include_path(null);


require HOA_PATH.DIRECTORY_SEPARATOR.'Hoa'.DIRECTORY_SEPARATOR.'Core'.DIRECTORY_SEPARATOR.'Core.php';


$hoa = Hoa\Core\Core::getInstance()->initialize([
    'root.application'  => __ROOT__,
    'root.data'         => __ROOT__ . DS . 'Data',
]);

event('hoa://Event/Exception')->attach(new Hoa\File\Write('hoa://Data/Variable/Log/Exception.log'));



/* ================================================ */



from('Hoa')
-> import('Database.Dal')
-> import('Router.Http')
-> import('Dispatcher.Basic')
-> import('Xyl~')
-> import('Xyl.Interpreter.Html~')
-> import('File.Read')
-> import('Http.Response~')
;

...
```
And `HOA_CREATOR` may be used for debugging. 