### PR TITLE
Dropping PHP5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "source": "http://git.hoa-project.net/"
     },
     "require": {
-        "php"    : ">=5.3.3",
+        "php"    : ">=5.4.0",
         "ext-spl": "*"
     },
     "suggest": {


### PR DESCRIPTION
Fix https://github.com/hoaproject/Core/issues/41.
I use `>=` and not `~` because `~5.4.0` would exclude `6.*`.
