### PR TITLE
Do not deal with un-namespaced classes

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -310,10 +310,7 @@ class Consistency {
     public static function autoload ( $classname ) {
 
         if(false === strpos($classname, '\\'))
-            if(false === strpos($classname, '_'))
-                return false;
-            else
-                $classname = str_replace('_', '\\', $classname);
+            return false;
 
         $classname = ltrim($classname, '\\');
 


### PR DESCRIPTION
Let other autoloaders handle them.

Should fix https://github.com/hoaproject/Core/issues/51.
It is not yet a PSR-4 autoloader. We just drop un-namespaced classes.
