### PR TITLE
Allow dash in command name

### DIFF
--- a/Bin/Hoa.php
+++ b/Bin/Hoa.php
@@ -73,7 +73,7 @@ try {
     $router = new \Hoa\Router\Cli();
     $router->get(
         'g',
-        '(?:(?<vendor>\w+)\s+)?(?<library>\w+)?(?::(?<command>\w+))?(?<_tail>.*?)',
+        '(?:(?<vendor>\w+)\s+)?(?<library>\w+)?(?::(?<command>[\w\-]+))?(?<_tail>.*?)',
         'main',
         'main',
         array(
@@ -85,7 +85,7 @@ try {
 
     $dispatcher = new \Hoa\Dispatcher\Basic(array(
         'synchronous.controller'
-            => '(:%variables.vendor:lU:)\(:%variables.library:lU:)\Bin\(:%variables.command:lU:)',
+            => '(:%variables.vendor:lU:)\(:%variables.library:lU:)\Bin\(:%variables.command:lUs/-//:)',
         'synchronous.action'
             => 'main'
     ));


### PR DESCRIPTION
We just remove dashes in command name. For example, for the `Hoa\Devtools\Bin\Requiresnapshot` command, we can write:

``` sh
$ hoa devtools:require-snapshot
```

instead of

``` sh
$ hoa devtools:requiresnapshot
```

The first one is far more readable.

Of course, we can also write:

``` sh
$ hoa devtools:r-e-q-u-i-r-e-s-n-a-p-s-h-o-t--------
```

and it will work.

Pro: help to read long commands.
Con: several “names” for the same command, which is not… good :-/.

Thoughts?

/cc @hoaproject/hoackers 
