### PR TITLE
`notify` no longer checks the source reference

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -338,17 +338,6 @@ class Event {
                 'Event ID %s does not exist, cannot send notification.',
                 3, $eventId);
 
-        $sourceRef = self::$_register[$eventId][1];
-
-        if(!($source instanceof $sourceRef))
-            throw new Core\Exception(
-                'Source cannot create a notification because it\'s the ' .
-                'source or source\'s child (source reference: %s, given %s.',
-                4, [
-                    is_object($sourceRef) ? get_class($sourceRef) : $sourceRef,
-                    get_class($source)
-                ]);
-
         $data->setSource($source);
         $event = self::getEvent($eventId);
 


### PR DESCRIPTION
Because, for instance, in the case of a borrowed stream, the source reference will be the original stream handler, so an exception will be fired. This verification is too strong and not always necessary. This is part to the user to check it.