### PR TITLE
Remove `setlocale`

### DIFF
--- a/Core.php
+++ b/Core.php
@@ -170,8 +170,6 @@ class Core implements Parameter\Parameterizable {
                         ['hoa']
                     )));
 
-        setlocale(LC_CTYPE, 'C');
-
         if(true === function_exists('mb_internal_encoding'))
             mb_internal_encoding('UTF-8');
 


### PR DESCRIPTION
This is the cause of several issues in projects with a specific `setlocale` configuration. Hoa **must not** modify the runtime environment.

Thanks @stephpy and @th3fallen for the report.

Fix #77.