### PR TITLE
`stream_open` returns `false` if not a resource

### DIFF
--- a/Protocol.php
+++ b/Protocol.php
@@ -792,6 +792,10 @@ class Wrapper
             );
         }
 
+        if (false === is_resource($openedPath)) {
+            return false;
+        }
+
         $this->_stream     = $openedPath;
         $this->_streamName = $path;
 


### PR DESCRIPTION
Fix #86.

When `stream_open` is not able to open the stream, let say because it cannot read it, then `stream_open` must return `false`. `true` was always returned, it was a damn stupid error!