### PR TITLE
Update retro-compatibility with PHP7

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -943,24 +943,18 @@ if (!function_exists('trait_exists')) {
 
 if (70000 > PHP_VERSION_ID) {
     /**
-     * Implement a fake BaseException class, introduced in PHP7.0.
+     * Implement a fake Throwable class, introduced in PHP7.0.
      */
-    abstract class BaseException extends Exception
+    interface Throwable
     {
-    }
-
-    /**
-     * Implement a fake EngineException class, introduced in PHP7.0.
-     */
-    class EngineException extends Exception
-    {
-    }
-
-    /**
-     * Implement a fake ParseException class, introduced in PHP7.0.
-     */
-    class ParseException extends Exception
-    {
+        public function getMessage();
+        public function getCode();
+        public function getFile();
+        public function getLine();
+        public function getTrace();
+        public function getPrevious();
+        public function getTraceAsString();
+        public function __toString();
     }
 }
 


### PR DESCRIPTION
Fix #88.

The new exception architecture introduced in PHP7 [1] has been totally redesigned [2]. This patch updates the retro-compatibility classes according to this new architecture. Consequently, the `BaseException` class has been removed, along with `EngineException` and `ParseException`. While these latters could be implemented (not as is), we prefer to, so far, only implement the `Throwable` interface. Let see if we can implement (still for the retro-compatibility) the `Error`, `TypeError` and `ParseError` class.

[1]: https://wiki.php.net/rfc/engine_exceptions_for_php7
[2]: https://wiki.php.net/rfc/throwable-interface