### PR TITLE
Remove the `bin` property in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         },
         "files": ["Core.php"]
     },
-    "bin"  : ["Bin/hoa"],
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev"


### PR DESCRIPTION
This is defined by `Hoa\Cli` now.